### PR TITLE
No longer matches (unix) invisible files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@
       path = require('path'),
 
       isSassFile = function isSassFile(filename) {
-        return (/^[^_].*\.scss/).test(path.basename(filename));
+        return (/^[^_.].*\.scss/).test(path.basename(filename));
       },
 
       isPartial = function isPartial(filename) {


### PR DESCRIPTION
I was having issues with the plugin choking on my vim .swp files... I figured it might make sense just not to match hidden files at all?
