### PR TITLE
Handle errors using metalsmith pipeline

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@
               done();
             },
             error: function(err) {
-              throw err;
+              done(err);
             }
           });
         } else if (isPartial(filename) === true) {

--- a/test/fixtures/invalid/src/invalid.scss
+++ b/test/fixtures/invalid/src/invalid.scss
@@ -1,0 +1,3 @@
+.invalid {
+  aninvalidrule!
+}

--- a/test/test.js
+++ b/test/test.js
@@ -30,9 +30,7 @@
             outputStyle: 'expanded'
           }))
           .build(function (err) {
-            if (err) {
-              throw err;
-            }
+            assert.equal(err, null, "There shouldn't be any error.")
             equal(join(__dirname, 'fixtures/basic/build'), join(__dirname, 'fixtures/basic/expected'));
             done();
           });
@@ -67,6 +65,20 @@
             }
             equal(join(__dirname, 'fixtures/dotfiles/build'), join(__dirname, 'fixtures/dotfiles/expected'));
             assert(!exists(join(__dirname, 'fixtures/dotfiles/build/.badfile.css')));
+            done();
+          });
+      });
+
+      it('should fail when invalid file provided', function(done) {
+        metalsmith(__dirname)
+          .source('fixtures/invalid/src')
+          .destination('fixtures/invalid/build')
+          .use(sass({
+            outputStyle: 'expanded'
+          }))
+          .build(function (err) {
+            assert.notEqual(err, null, "Error should be set.")
+            assert(!exists(join(__dirname, 'fixtures/invalid/build/invalid.scss')));
             done();
           });
       });


### PR DESCRIPTION
Handle errors as told here:
http://www.robinthrift.com/posts/metalsmith-part-3-refining-our-tools/#a-note-error-handling

Doing that, metalsmith's `build(function(err, files) {})` can handle it.

Currently if a scss file fails building, it is impossible to catch it through metalsmith pipeline.
