### PR TITLE
Use data file stream rather than file path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,8 +21,13 @@
             outputDir = this.outputDir || path.dirname(filename);
 
         if (isSassFile(filename) === true) {
+          // Append the file's base path to the available include paths.
+          includes.push(basePath);
+
+          // Compile the file using SASS.
           sass.render({
-            file: path.join(basePath, filename),
+            // Use the file's content stream buffer rather than the file path.
+            data: file.contents.toString(),
             includePaths: includes,
             imagePath: imagePath,
             outputStyle: outputStyle,

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@
               done();
             },
             error: function(err) {
+              console.log(err);
               done(err);
             }
           });

--- a/test/fixtures/front-matter/expected/front-matter.css
+++ b/test/fixtures/front-matter/expected/front-matter.css
@@ -1,0 +1,2 @@
+.shouldprint {
+  background: #0ff; }

--- a/test/fixtures/front-matter/src/front-matter.scss
+++ b/test/fixtures/front-matter/src/front-matter.scss
@@ -1,0 +1,9 @@
+---
+title: This is a SASS file with front matter data.
+---
+
+$color: #0ff;
+
+.shouldprint {
+ background: $color;
+}

--- a/test/fixtures/front-matter/src/front-matter.scss
+++ b/test/fixtures/front-matter/src/front-matter.scss
@@ -1,5 +1,5 @@
 ---
-title: This is a SASS file with front matter data.
+title: SASS file with YMAL Front-Matter, which is ignored by Metalsmith.
 ---
 
 $color: #0ff;

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,7 @@
         join(__dirname, 'fixtures/partials/build'),
         join(__dirname, 'fixtures/outputDir/build'),
         join(__dirname, 'fixtures/dotfiles/build'),
+        join(__dirname, 'fixtures/front-matter/build'),
         join(__dirname, 'fixtures/invalid/build')
       ];
       each(dirsToClean, rm, done);
@@ -68,6 +69,23 @@
             assert(!exists(join(__dirname, 'fixtures/dotfiles/build/.badfile.css')));
             done();
           });
+      });
+
+      it('should operate correctly around YAML front matter', function (done) {
+        metalsmith(__dirname)
+        .source('fixtures/front-matter/src')
+        .destination('fixtures/front-matter/build')
+        .use(sass({
+          outputStyle: 'expanded'
+        }))
+        .build(function (err) {
+          if (err) {
+            throw err;
+          }
+          equal(join(__dirname, 'fixtures/front-matter/build'), join(__dirname, 'fixtures/front-matter/expected'));
+          assert(!exists(join(__dirname, 'fixtures/dotfiles/build/.badfile.css')));
+          done();
+        });
       });
 
       it('should fail when invalid file provided', function(done) {


### PR DESCRIPTION
`node-sass` can use the [`data`](https://github.com/sass/node-sass#data) attribute to bring in a file buffer stream so that it doesn't have to read the file over and over again. This also fixes the include paths for partials, bringing in the base path of the file so that it understands where the file is.