### PR TITLE
Indented syntax support and compiler pass-through options

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,27 @@ all imports own its own, but if you are getting `not found` errors, try manually
 Base path to use when evaluating `image-url()` functions in a stylesheet. Path will be prefixed to
 the value.
 
+### passthroughOptions
+
+Object passed on as options directly to the compiler;
+see [node-sass#options](https://github.com/sass/node-sass#options) for the full list.
+
+```js
+Metalsmith()
+  .source("src/")
+  .destination("build/")
+  .use(sass({
+    outputStyle: "expanded",
+    passthroughOptions: {
+      precision: 2,
+      sourceComments: true
+    }
+  }))
+  .build(function () {
+    done();
+  });
+```
+
 ## Credits
 
 Thanks to [Segment.io](http://github.com/segmentio) for creating and open-sourcing

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,13 +4,18 @@
   var sass = require('node-sass'),
       each = require('async').each,
       path = require('path'),
+      extend = require('extend-object'),
 
       isSassFile = function isSassFile(filename) {
-        return (/^[^_.].*\.scss/).test(path.basename(filename));
+        return (/^[^_.].*\.s[ca]ss/).test(path.basename(filename));
+      },
+
+      isIndentedSassFile = function isIndentedSassFile(filename) {
+        return (/^[^_.].*\.sass/).test(path.basename(filename));
       },
 
       isPartial = function isPartial(filename) {
-        return (/^_.*\.scss/).test(path.basename(filename));
+        return (/^_.*\.s[ca]ss/).test(path.basename(filename));
       },
 
       compile = function(basePath, files, filename, done) {
@@ -19,24 +24,27 @@
             outputStyle = this.outputStyle || 'compressed',
             imagePath = this.imagePath || '/',
             outputDir = this.outputDir || path.dirname(filename),
-            fileDir = path.dirname(path.join(basePath, filename));
+            fileDir = path.dirname(path.join(basePath, filename)),
+            passthroughOptions = this.passthroughOptions;
 
         if (isSassFile(filename) === true) {
           // Append the file's base path to the available include paths.
           includes.push(fileDir);
 
-          // Compile the file using SASS.
-          sass.render({
+          // Extend options object to include passthrough for sass
+          var options = {
             // Use the file's content stream buffer rather than the file path.
             data: file.contents.toString(),
             includePaths: includes,
             imagePath: imagePath,
             outputStyle: outputStyle,
+            // enable indented syntax for '.sass' files
+            indentedSyntax: isIndentedSassFile(filename),
             success: function handleSuccess(css) {
               // replace contents
               file.contents = new Buffer(css);
               // rename file extension
-              files[path.join(outputDir, path.basename(filename).replace('.scss', '.css'))] = file;
+              files[path.join(outputDir, path.basename(filename).replace('.scss', '.css').replace('.sass', '.css'))] = file;
               delete files[filename];
               done();
             },
@@ -46,7 +54,12 @@
               }
               done(err);
             }
-          });
+          }
+
+          extend(options, passthroughOptions);
+
+          // Compile the file using SASS.
+          sass.render(options);
         } else if (isPartial(filename) === true) {
           delete files[filename];
           done();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "mocha": "^1.20.1",
     "rimraf": "^2.2.6",
     "assert-dir-equal": "^1.0.1",
-    "assert": "^1.1.1"
+    "assert": "^1.1.1",
+    "extend-object": "^1.0.0"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/test/fixtures/basic/expected/main-sass.css
+++ b/test/fixtures/basic/expected/main-sass.css
@@ -1,0 +1,2 @@
+.myclass {
+  background: #eee; }

--- a/test/fixtures/basic/src/main-sass.sass
+++ b/test/fixtures/basic/src/main-sass.sass
@@ -1,0 +1,4 @@
+$color: #eee
+
+.myclass
+  background: $color

--- a/test/fixtures/passthrough/expected/main.css
+++ b/test/fixtures/passthrough/expected/main.css
@@ -1,0 +1,3 @@
+/* test comment */
+body {
+  margin: 1.12em; }

--- a/test/fixtures/passthrough/src/main.sass
+++ b/test/fixtures/passthrough/src/main.sass
@@ -1,0 +1,5 @@
+$test: 1.123456789
+
+/* test comment */
+body
+  margin: #{$test}em

--- a/test/test.js
+++ b/test/test.js
@@ -105,6 +105,25 @@
         });
       });
 
+      it('should pass options through to node-sass', function (done) {
+        metalsmith(__dirname)
+        .source('fixtures/passthrough/src')
+        .destination('fixtures/passthrough/build')
+        .use(sass({ passthroughOptions: {
+          outputStyle: 'expanded',
+          precision: 2,
+          sourceComments: false
+        } }))
+        .build(function (err) {
+          if (err) {
+            throw err;
+          }
+          assert.equal(err, null, "There shouldn't be any error.");
+          equal(join(__dirname, 'fixtures/passthrough/build'), join(__dirname, 'fixtures/passthrough/expected'));
+          done();
+        });
+      });
+
       it('should correctly report errors to Metalsmith', function(done) {
         metalsmith(__dirname)
           .source('fixtures/invalid/src')


### PR DESCRIPTION
Hey, not a pro by any means, but I was missing some functionality and thought I'd give it a go at adding following changes:
- Added support for indented sass syntax
- Will autodetect syntax style based on extension (.scss/.sass)
- Added passthroughOptions to enable sending options directly to compiler
Hope this helps!