### PR TITLE
Updated mocha and node-sass

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,9 +32,9 @@
             includePaths: includes,
             imagePath: imagePath,
             outputStyle: outputStyle,
-            success: function handleSuccess(css) {
+            success: function handleSuccess(result) {
               // replace contents
-              file.contents = new Buffer(css);
+              file.contents = new Buffer(result.css);
               // rename file extension
               files[path.join(outputDir, path.basename(filename).replace('.scss', '.css'))] = file;
               delete files[filename];

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "homepage": "https://github.com/stevenschobert/metalsmith-sass",
   "devDependencies": {
     "metalsmith": "^1.0.1",
-    "mocha": "^1.20.1",
+    "mocha": "^2.1.0",
     "rimraf": "^2.2.6",
     "assert-dir-equal": "^1.0.1",
     "assert": "^1.1.1"
   },
   "dependencies": {
     "async": "^0.9.0",
-    "node-sass": "^1.2.0"
+    "node-sass": "^2.0.1"
   }
 }


### PR DESCRIPTION
For node 0.12.0	support.

- mocha@2.1.0 - fixes customFds deprecation error
- node-sass@2.0.1 - support for node 0.12.0

Ran npm test and also tested on a personal project, no problems.