### PR TITLE
Upgrade to node-sass 3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "dependencies": {
     "async": "^1.0.0",
-    "node-sass": "^3.1.2"
+    "node-sass": "^3.3.2"
   }
 }


### PR DESCRIPTION
I was getting libsass errors after upgrading to Node 4.0. Seems upgrading the node-sass version fixes these errors.