### PR TITLE
node-sass is a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,13 @@
     "mocha": "^2.2.5",
     "rimraf": "^2.3.4",
     "assert-dir-equal": "^1.0.1",
-    "assert": "^1.3.0"
+    "assert": "^1.3.0",
+    "node-sass": "^3.1.2"
   },
   "dependencies": {
-    "async": "^1.0.0",
-    "node-sass": "^3.1.2"
+    "async": "^1.0.0"
+  },
+  "peerDependencies": {
+    "node-sass": "^3.0.0"
   }
 }


### PR DESCRIPTION
In order to let the user easily control the node-sass version, it should
be a peerDependency.

This is a BREAKING CHANGE.
