### PR TITLE
Bump node-sass@v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "dependencies": {
     "async": "^1.0.0",
-    "node-sass": "^3.1.2"
+    "node-sass": "^4.0.0"
   }
 }

--- a/test/fixtures/maps/expected/css/main.css.map
+++ b/test/fixtures/maps/expected/css/main.css.map
@@ -9,6 +9,6 @@
 		"@import 'vendor/part';\n",
 		"$color: #eee;\n\n.myclass {\n  background: $color;\n}\n"
 	],
-	"mappings": "ACEA,QAAQ,AAAC,CACP,UAAU,CAHJ,IAAI,CAEF",
-	"names": []
+	"names": [],
+	"mappings": "ACEA,AAAA,QAAQ,AAAC,CACP,UAAU,CAHJ,IAAI,CAIX"
 }


### PR DESCRIPTION
Even if the major has been incremented, it's BC with v3.13.1 as explained in the [release notes](https://github.com/sass/node-sass/releases/tag/v4.0.0).