### PR TITLE
Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "dependencies": {
     "async": "^2.1.4",
-    "node-sass": "^4.2.0"
+    "node-sass": "^4.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "assert": "^1.4.1"
   },
   "dependencies": {
-    "async": "^2.1.4",
+    "async": "^2.6.0",
     "node-sass": "^4.7.2"
   }
 }


### PR DESCRIPTION
Most importantly, this PR bumps the `node-sass` dependency to allow it to function in modern nodejs environments (nodejs 7, 8, 9).  As-is, users must rollback the running version of node to utilize this metalsmith plugin.